### PR TITLE
Add coverage check to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-cov
       - name: Run tests
         env:
           OPENAI_API_KEY: dummy

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=app --cov=gpt_handler.py --cov=stream_handler.py --cov-report=term-missing --cov-fail-under=40

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy==1.15.3
 sounddevice==0.5.2
 python-socketio==5.13.0
 eventlet==0.33.3
+pytest-cov==6.1.1


### PR DESCRIPTION
## Summary
- enforce coverage via pytest.ini
- add pytest-cov to dependencies and GitHub Actions workflow

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68498eeab900832da809760e0ced0297