### PR TITLE
Fix realtime stop event

### DIFF
--- a/stream_handler.py
+++ b/stream_handler.py
@@ -79,7 +79,7 @@ class OpenAIStreamHandler:
 
     def stop_audio(self):
         if self.connected.is_set():
-            self.ws.send(json.dumps({"type": "input_audio.buffer.stop"}))
+            self.ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
 
     def close(self):
         if self.ws:


### PR DESCRIPTION
## Summary
- use `input_audio_buffer.commit` event when ending speech

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498fe0f1a8832d940518fc61ebabde