### PR TITLE
Fix realtime stop event

### DIFF
--- a/stream_handler.py
+++ b/stream_handler.py
@@ -79,7 +79,9 @@ class OpenAIStreamHandler:
 
     def stop_audio(self):
         if self.connected.is_set():
-            self.ws.send(json.dumps({"type": "input_audio.buffer.stop"}))
+            # Finalize the input audio and request a response
+            self.ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+            self.ws.send(json.dumps({"type": "response.create"}))
 
     def close(self):
         if self.ws:


### PR DESCRIPTION
## Summary
- use `input_audio_buffer.commit` event when ending speech
- request generation via `response.create`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498fe0f1a8832d940518fc61ebabde