### PR TITLE
Add favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__/
 
 # Fichiers logs génériques
 *.log
+.coverage
+static/favicon.png

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Vous pouvez également appeler l'endpoint `/api/generate_test_audio` pour géné
 - `app.py` – application Flask et communication WebSocket avec l'API OpenAI
 - `templates/` – templates HTML (page de connexion et interface vocale)
 - `requirements.txt` – dépendances Python
+- `static/favicon.png` – icône de l'application affichée dans l'onglet du navigateur
 
 ## Licence
 
 Ce projet est fourni tel quel, sans garantie. Utilisez-le à vos risques et périls.
+Le fichier `static/favicon.png` provient du projet [twemoji](https://github.com/twitter/twemoji/blob/master/assets/72x72/1f3a4.png)
+sous licence Creative Commons Attribution 4.0 (CC-BY 4.0).

--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ import base64
 import wave
 import time
 from datetime import datetime
-from flask import Flask, render_template, request, jsonify, session, redirect, url_for
+from flask import Flask, render_template, request, jsonify, session, redirect, url_for, send_from_directory
 from flask_socketio import SocketIO, emit, join_room, leave_room
 import logging
 from dotenv import load_dotenv
@@ -300,6 +300,13 @@ class VoiceSession:
                 self.add_event('error', f'Erreur sauvegarde audio: {str(e)}', 'error')
 
 # Routes Flask
+
+@app.route('/favicon.ico')
+def favicon():
+    """Fichier d'icône pour l'application"""
+    return send_from_directory(os.path.join(app.root_path, 'static'),
+                               'favicon.png', mimetype='image/png')
+
 @app.route('/')
 def login():
     """Page de connexion"""

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Assistant Vocal OpenAI - Connexion</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <style>
         * {
             margin: 0;

--- a/templates/voice_interface.html
+++ b/templates/voice_interface.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Assistant Vocal OpenAI - Interface</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.2/socket.io.js"></script>
     <style>
         * {

--- a/templates/voice_interface01.html
+++ b/templates/voice_interface01.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Assistant Vocal OpenAI - Interface</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.2/socket.io.js"></script>
     <style>
         * {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,6 +32,23 @@ def test_login_page(client):
     assert resp.status_code == 200
 
 
+def test_favicon(client):
+    path = os.path.join('static', 'favicon.png')
+    created = False
+    if not os.path.exists(path):
+        os.makedirs('static', exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(b'\x89PNG\r\n\x1a\n')
+        created = True
+
+    try:
+        resp = client.get('/favicon.ico')
+        assert resp.status_code == 200
+    finally:
+        if created:
+            os.remove(path)
+
+
 def test_login_success(client):
     resp = client.post('/login', data={'username': 'tester', 'password': ''})
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- serve a favicon from the static folder
- reference the favicon in HTML templates
- document icon licensing
- test the `/favicon.ico` route
- ignore the binary icon file so it's user-supplied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849967725b8832db901e76f6ee139a1