### PR TITLE
Add upload page and navigation link

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import json
 import queue
 import threading
 import websocket
+from werkzeug.utils import secure_filename
 from stream_handler import OpenAIStreamHandler
 import numpy as np
 import base64
@@ -318,6 +319,27 @@ def voice_interface():
     if 'user_id' not in session:
         return redirect(url_for('login'))
     return render_template('voice_interface.html')
+
+
+@app.route('/upload', methods=['GET', 'POST'])
+def upload():
+    """Page d'upload simple pour envoyer un fichier audio"""
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+
+    message = None
+    if request.method == 'POST':
+        uploaded = request.files.get('file')
+        if uploaded and uploaded.filename:
+            os.makedirs(os.path.join('static', 'uploads'), exist_ok=True)
+            filename = secure_filename(uploaded.filename)
+            save_path = os.path.join('static', 'uploads', filename)
+            uploaded.save(save_path)
+            message = f"Fichier '{filename}' téléchargé"
+        else:
+            message = 'Aucun fichier sélectionné'
+
+    return render_template('upload.html', message=message)
 
 @app.route('/login', methods=['POST'])
 def do_login():

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Upload audio</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        .nav-btn {
+            background: none;
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            color: white;
+            padding: 0.5rem 1rem;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            margin: 0 0.5rem;
+        }
+        .nav-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
+        .container {
+            background: rgba(255, 255, 255, 0.95);
+            padding: 2rem;
+            border-radius: 20px;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Uploader un fichier audio</h1>
+        {% if message %}
+        <p>{{ message }}</p>
+        {% endif %}
+        <form method="POST" enctype="multipart/form-data">
+            <input type="file" name="file" accept="audio/*" required>
+            <div style="margin-top:1rem;">
+                <button type="submit" class="nav-btn">Envoyer</button>
+                <a href="{{ url_for('voice_interface') }}" class="nav-btn">Retour</a>
+                <a href="{{ url_for('logout') }}" class="nav-btn">Déconnexion</a>
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/templates/voice_interface.html
+++ b/templates/voice_interface.html
@@ -82,7 +82,7 @@
             animation: pulse 2s infinite;
         }
 
-        .logout-btn {
+        .nav-btn {
             background: none;
             border: 1px solid rgba(255, 255, 255, 0.3);
             color: white;
@@ -92,7 +92,7 @@
             transition: all 0.3s;
         }
 
-        .logout-btn:hover {
+        .nav-btn:hover {
             background: rgba(255, 255, 255, 0.1);
         }
 
@@ -454,7 +454,8 @@
                 <div class="status-dot" id="statusDot"></div>
                 <span id="statusText">Déconnecté</span>
             </div>
-            <button class="logout-btn" onclick="logout()">Déconnexion</button>
+            <a href="{{ url_for('upload') }}" class="nav-btn">Upload</a>
+            <button class="nav-btn" onclick="logout()">Déconnexion</button>
         </div>
     </div>
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@ import sys
 import importlib
 import base64
 import json
+import io
 import pytest
 
 # Configurer les variables d'environnement requises avant l'import de l'application
@@ -131,3 +132,19 @@ def test_dialogue_flow(client, monkeypatch):
     resp = client.get('/logout')
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/')
+
+
+def test_upload_page(client):
+    client.post('/login', data={'username': 'tester', 'password': ''})
+    resp = client.get('/upload')
+    assert resp.status_code == 200
+
+
+def test_file_upload(client):
+    client.post('/login', data={'username': 'tester', 'password': ''})
+    data = {
+        'file': (io.BytesIO(b'data'), 'sample.wav')
+    }
+    resp = client.post('/upload', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert b'sample.wav' in resp.data


### PR DESCRIPTION
## Summary
- add simple audio upload route and page
- link to new page from voice interface
- support file uploads via Flask
- test upload functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854650b8534832db1fb71e2a641a805